### PR TITLE
Dockerize fonts installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below or some instructions to install this package
 ```
 git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
-./install_fonts.sh
+sudo ./install_fonts.sh
 ./install_pdfparser.sh
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf

--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ Available under GPL v3 or any later version license (libpoppler is also GPL).
 Below or some instructions to install this package
 
 ```
-git clone --depth 1 https://github.com/izderadicka/pdfparser.git
+git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
-./build_poppler.sh
-pip install cython
-POPPLER_ROOT=poppler_src ./setup.py install
+./install_pdfparser.sh
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Below or some instructions to install this package
 ```
 git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
+./install_fonts.sh
 ./install_pdfparser.sh
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf

--- a/README.md
+++ b/README.md
@@ -23,43 +23,6 @@ Available under GPL v3 or any later version license (libpoppler is also GPL).
 
 Below or some instructions to install this package
 
-### CentOS 7 - system-wide libpoppler (pkg-config method)
-
-Install the poppler-devel package (Tested with version 0.26.5-16.el7)
-
-    yum install poppler-devel
-
-Install cython
-    
-    pip install cython
-
-Install the repo
-    
-    pip install git+https://github.com/izderadicka/pdfparser
-
-### CentOS 7 - self compiled method
-
-Clone this repo and enter into the root folder
-
-    cd /git/repos/
-    git clone https://github.com/izderadicka/pdfparser.git
-    cd pdfparser
-
-Clone the poppler repo and install (similar to build_poppler.sh)
-    
-    yum install openjpeg2-devel libjpeg-turbo-devel
-    git clone --depth 1 git://git.freedesktop.org/git/poppler/poppler poppler_src
-    cd poppler_src
-    ./autogen.sh
-    ./configure --disable-poppler-qt4 --disable-poppler-qt5 --disable-poppler-cpp --disable-gtk-test --disable-splash-output --disable-utils
-    make
-    cp poppler/.libs/libpoppler.so.?? ../pdfparser/
-    cd ..
-    POPPLER_ROOT=poppler_src python setup.py install
-    
- 
-### Debian like - self compiled method
- 
 ```
 git clone --depth 1 https://github.com/izderadicka/pdfparser.git
 cd pdfparser
@@ -68,14 +31,6 @@ pip install cython
 POPPLER_ROOT=poppler_src ./setup.py install
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf
-```
-
-### Debian like -  system wide libpoppler 
-```
-sudo apt-get update
-sudo apt-get install -y libpoppler-private-dev
-pip install cython
-pip install git+https://github.com/izderadicka/pdfparser
 ```
     
 

--- a/install_fonts.sh
+++ b/install_fonts.sh
@@ -23,7 +23,7 @@
 
 set -e
 
-sudo apt-get install -y cabextract fontconfig
+apt-get install -y cabextract fontconfig
 
 MS_FONTS_ARCHIVE=IELPKTH.CAB
 MS_FONTS_DIR=/usr/share/fonts/truetype/msttcorefonts/
@@ -34,15 +34,15 @@ VISTA_FONTS_DIR=/usr/share/fonts/truetype/vistafonts/
 TMPDIR=`mktemp -d`
 trap 'rm -rf $TMPDIR $MS_FONTS_ARCHIVE $VISTA_FONTS_ARCHIVE' EXIT INT QUIT TERM
 
-sudo apt install ttf-mscorefonts-installer
+apt install ttf-mscorefonts-installer
 
 wget https://sourceforge.net/projects/corefonts/files/OldFiles/$MS_FONTS_ARCHIVE
 
 if cabextract -L -F 'tahoma*ttf' -d $TMPDIR $MS_FONTS_ARCHIVE
 then
-    sudo mv $TMPDIR/tahoma* $MS_FONTS_DIR
-    sudo chmod 600 $MS_FONTS_DIR/tahoma*
-    sudo fc-cache -fv $MS_FONTS_DIR
+    mv $TMPDIR/tahoma* $MS_FONTS_DIR
+    chmod 600 $MS_FONTS_DIR/tahoma*
+    fc-cache -fv $MS_FONTS_DIR
 else
     echo "ERROR: Failed to install Tahoma font!"
     exit 1
@@ -52,12 +52,12 @@ wget http://download.microsoft.com/download/f/5/a/f5a3df76-d856-4a61-a6bd-722f52
 
 if cabextract -L -F ppviewer.cab -d $TMPDIR $VISTA_FONTS_ARCHIVE
 then
-    sudo cabextract -L -F '*.TT[FC]' -d $VISTA_FONTS_DIR $TMPDIR/ppviewer.cab
+    cabextract -L -F '*.TT[FC]' -d $VISTA_FONTS_DIR $TMPDIR/ppviewer.cab
 
-    ( cd $VISTA_FONTS_DIR && sudo mv cambria.ttc cambria.ttf && sudo chmod 600 \
+    ( cd $VISTA_FONTS_DIR && mv cambria.ttc cambria.ttf && chmod 600 \
             calibri{,b,i,z}.ttf cambria{,b,i,z}.ttf candara{,b,i,z}.ttf \
             consola{,b,i,z}.ttf constan{,b,i,z}.ttf corbel{,b,i,z}.ttf )
-    sudo fc-cache -fv $VISTA_FONTS_DIR
+    fc-cache -fv $VISTA_FONTS_DIR
 else
     echo "ERROR: Failed to install Vista fonts!"
     exit 1

--- a/install_fonts.sh
+++ b/install_fonts.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# This file is part of pdfparser.
+#
+# pdfparse is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pdfparser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pdfparser.  If not, see <http://www.gnu.org/licenses/>.
+#
+# A part of this code was inspired by vistafonts-installer
+# (http://plasmasturm.org/code/vistafonts-installer/). vistafonts-installer
+# is a free software distributed under the terms of MIT License.
+# For more information about the license see the attached original
+# vistafonts-installer script.
+
+set -e
+
+sudo apt-get install -y cabextract fontconfig
+
+MS_FONTS_ARCHIVE=IELPKTH.CAB
+MS_FONTS_DIR=/usr/share/fonts/truetype/msttcorefonts/
+
+VISTA_FONTS_ARCHIVE=PowerPointViewer.exe
+VISTA_FONTS_DIR=/usr/share/fonts/truetype/vistafonts/
+
+TMPDIR=`mktemp -d`
+trap 'rm -rf $TMPDIR $MS_FONTS_ARCHIVE $VISTA_FONTS_ARCHIVE' EXIT INT QUIT TERM
+
+sudo apt install ttf-mscorefonts-installer
+
+wget https://sourceforge.net/projects/corefonts/files/OldFiles/$MS_FONTS_ARCHIVE
+
+if cabextract -L -F 'tahoma*ttf' -d $TMPDIR $MS_FONTS_ARCHIVE
+then
+    sudo mv $TMPDIR/tahoma* $MS_FONTS_DIR
+    sudo chmod 600 $MS_FONTS_DIR/tahoma*
+    sudo fc-cache -fv $MS_FONTS_DIR
+else
+    echo "ERROR: Failed to install Tahoma font!"
+    exit 1
+fi
+
+wget http://download.microsoft.com/download/f/5/a/f5a3df76-d856-4a61-a6bd-722f52a5be26/$VISTA_FONTS_ARCHIVE
+
+if cabextract -L -F ppviewer.cab -d $TMPDIR $VISTA_FONTS_ARCHIVE
+then
+    sudo cabextract -L -F '*.TT[FC]' -d $VISTA_FONTS_DIR $TMPDIR/ppviewer.cab
+
+    ( cd $VISTA_FONTS_DIR && sudo mv cambria.ttc cambria.ttf && sudo chmod 600 \
+            calibri{,b,i,z}.ttf cambria{,b,i,z}.ttf candara{,b,i,z}.ttf \
+            consola{,b,i,z}.ttf constan{,b,i,z}.ttf corbel{,b,i,z}.ttf )
+    sudo fc-cache -fv $VISTA_FONTS_DIR
+else
+    echo "ERROR: Failed to install Vista fonts!"
+    exit 1
+fi

--- a/install_fonts.sh
+++ b/install_fonts.sh
@@ -32,15 +32,15 @@ VISTA_FONTS_ARCHIVE=PowerPointViewer.exe
 VISTA_FONTS_DIR=/usr/share/fonts/truetype/vistafonts/
 
 TMPDIR=`mktemp -d`
-trap 'rm -rf $TMPDIR $MS_FONTS_ARCHIVE $VISTA_FONTS_ARCHIVE' EXIT INT QUIT TERM
+trap 'rm -rf $TMPDIR' EXIT INT QUIT TERM
+cd "$TMPDIR"
 
 apt install ttf-mscorefonts-installer
 
 wget https://sourceforge.net/projects/corefonts/files/OldFiles/$MS_FONTS_ARCHIVE
 
-if cabextract -L -F 'tahoma*ttf' -d $TMPDIR $MS_FONTS_ARCHIVE
+if cabextract -L -F 'tahoma*ttf' -d $MS_FONTS_DIR  $MS_FONTS_ARCHIVE
 then
-    mv $TMPDIR/tahoma* $MS_FONTS_DIR
     chmod 600 $MS_FONTS_DIR/tahoma*
     fc-cache -fv $MS_FONTS_DIR
 else
@@ -50,9 +50,9 @@ fi
 
 wget http://download.microsoft.com/download/f/5/a/f5a3df76-d856-4a61-a6bd-722f52a5be26/$VISTA_FONTS_ARCHIVE
 
-if cabextract -L -F ppviewer.cab -d $TMPDIR $VISTA_FONTS_ARCHIVE
+if cabextract -L -F ppviewer.cab $VISTA_FONTS_ARCHIVE
 then
-    cabextract -L -F '*.TT[FC]' -d $VISTA_FONTS_DIR $TMPDIR/ppviewer.cab
+    cabextract -L -F '*.TT[FC]' -d $VISTA_FONTS_DIR ppviewer.cab
 
     ( cd $VISTA_FONTS_DIR && mv cambria.ttc cambria.ttf && chmod 600 \
             calibri{,b,i,z}.ttf cambria{,b,i,z}.ttf candara{,b,i,z}.ttf \

--- a/install_fonts.sh
+++ b/install_fonts.sh
@@ -23,7 +23,7 @@
 
 set -e
 
-apt-get install -y cabextract fontconfig
+apt-get install -y cabextract coreutils debconf fontconfig wget
 
 MS_FONTS_ARCHIVE=IELPKTH.CAB
 MS_FONTS_DIR=/usr/share/fonts/truetype/msttcorefonts/

--- a/install_fonts.sh
+++ b/install_fonts.sh
@@ -35,7 +35,8 @@ TMPDIR=`mktemp -d`
 trap 'rm -rf $TMPDIR' EXIT INT QUIT TERM
 cd "$TMPDIR"
 
-apt install ttf-mscorefonts-installer
+echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+apt-get install -y ttf-mscorefonts-installer
 
 wget https://sourceforge.net/projects/corefonts/files/OldFiles/$MS_FONTS_ARCHIVE
 

--- a/install_pdfparser.sh
+++ b/install_pdfparser.sh
@@ -17,12 +17,6 @@
 #
 # Original version by Ivan Zderadicka  (https://github.com/izderadicka/pdfparser)
 # Adopted and modified by Rossum (https://github.com/rossumai/pdfparser)
-#
-# A part of this code was inspired by vistafonts-installer
-# (http://plasmasturm.org/code/vistafonts-installer/). vistafonts-installer
-# is a free software distributed under the terms of MIT License.
-# For more information about the license see the attached original
-# vistafonts-installer script.
 
 set -e
 
@@ -30,45 +24,7 @@ set -e
 need_sudo=`python -c 'import sys; print(not hasattr(sys, "real_prefix") and (not hasattr(sys, "base_prefix") or sys.prefix == sys.base_prefix))'`
 
 sudo apt-get update
-sudo apt-get install -y cmake libtool pkg-config gettext fontconfig libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev cabextract
-
-MS_FONTS_ARCHIVE=IELPKTH.CAB
-MS_FONTS_DIR=/usr/share/fonts/truetype/msttcorefonts/
-
-VISTA_FONTS_ARCHIVE=PowerPointViewer.exe
-VISTA_FONTS_DIR=/usr/share/fonts/truetype/vistafonts/
-
-TMPDIR=`mktemp -d`
-trap 'rm -rf $TMPDIR $MS_FONTS_ARCHIVE $VISTA_FONTS_ARCHIVE' EXIT INT QUIT TERM
-
-sudo apt install ttf-mscorefonts-installer
-
-wget https://sourceforge.net/projects/corefonts/files/OldFiles/$MS_FONTS_ARCHIVE
-
-if cabextract -L -F 'tahoma*ttf' -d $TMPDIR $MS_FONTS_ARCHIVE
-then
-    sudo mv $TMPDIR/tahoma* $MS_FONTS_DIR
-    sudo chmod 600 $MS_FONTS_DIR/tahoma*
-    sudo fc-cache -fv $MS_FONTS_DIR
-else
-    echo "ERROR: Failed to install Tahoma font!"
-    exit 1
-fi
-
-wget http://download.microsoft.com/download/f/5/a/f5a3df76-d856-4a61-a6bd-722f52a5be26/$VISTA_FONTS_ARCHIVE
-
-if cabextract -L -F ppviewer.cab -d $TMPDIR $VISTA_FONTS_ARCHIVE
-then
-    sudo cabextract -L -F '*.TT[FC]' -d $VISTA_FONTS_DIR $TMPDIR/ppviewer.cab
-
-    ( cd $VISTA_FONTS_DIR && sudo mv cambria.ttc cambria.ttf && sudo chmod 600 \
-            calibri{,b,i,z}.ttf cambria{,b,i,z}.ttf candara{,b,i,z}.ttf \
-            consola{,b,i,z}.ttf constan{,b,i,z}.ttf corbel{,b,i,z}.ttf )
-    sudo fc-cache -fv $VISTA_FONTS_DIR
-else
-    echo "ERROR: Failed to install Vista fonts!"
-    exit 1
-fi
+sudo apt-get install -y cmake libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev
 
 if [[ ${need_sudo} == 'True' ]]; then sudo pip install -r requirements.txt; else pip install -r requirements.txt; fi
 


### PR DESCRIPTION
This is the first part of the attempt to be able to run `install_pdfparser.sh` inside a Docker container. The main changes are:

- remove unsupported installation instructions (they aren't supported, right?)
- update the supported installation instructions
- remove `sudo` from the script because there is no `sudo` in the container
- install `ttf-mscorefonts-installer` without user interaction
- install `wget` because there is no `wget` in the container

While I was at at, I've introduced one more improvement:

- use a temporary directory in order to not mess up user's home directory
