### PR TITLE
Dockerize Poppler building

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Below or some instructions to install this package
 git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
 sudo ./install_fonts.sh
-./build_poppler.sh
+sudo ./build_poppler.sh
 ./install_pdfparser.sh
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Below or some instructions to install this package
 git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
 sudo ./install_fonts.sh
+./build_poppler.sh
 ./install_pdfparser.sh
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf

--- a/build_poppler.sh
+++ b/build_poppler.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This file is part of pdfparser.
+#
+# pdfparse is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pdfparser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pdfparser.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Original version by Ivan Zderadicka  (https://github.com/izderadicka/pdfparser)
+# Adopted and modified by Rossum (https://github.com/rossumai/pdfparser)
+
+set -e
+
+sudo apt-get install -y cmake libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev libcairo2-dev
+git clone --depth 1 --branch poppler-0.61.1 https://anongit.freedesktop.org/git/poppler/poppler.git
+cd poppler
+cmake -DCMAKE_BUILD_TYPE=release -DENABLE_CPP=OFF -DENABLE_GLIB=ON -DENABLE_QT4=OFF -DENABLE_QT5=OFF  -DBUILD_GTK_TESTS=OFF -DENABLE_SPLASH=OFF -DENABLE_UTILS=OFF
+make

--- a/build_poppler.sh
+++ b/build_poppler.sh
@@ -20,8 +20,9 @@
 
 set -e
 
-sudo apt-get install -y cmake libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev libcairo2-dev
+apt-get install -y cmake libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev libcairo2-dev
 git clone --depth 1 --branch poppler-0.61.1 https://anongit.freedesktop.org/git/poppler/poppler.git
 cd poppler
 cmake -DCMAKE_BUILD_TYPE=release -DENABLE_CPP=OFF -DENABLE_GLIB=ON -DENABLE_QT4=OFF -DENABLE_QT5=OFF  -DBUILD_GTK_TESTS=OFF -DENABLE_SPLASH=OFF -DENABLE_UTILS=OFF
 make
+chown --recursive $SUDO_UID: .

--- a/build_poppler.sh
+++ b/build_poppler.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-apt-get install -y cmake libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev libcairo2-dev
+apt-get install -y coreutils git gcc g++ cmake make libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev libcairo2-dev
 git clone --depth 1 --branch poppler-0.61.1 https://anongit.freedesktop.org/git/poppler/poppler.git
 cd poppler
 cmake -DCMAKE_BUILD_TYPE=release -DENABLE_CPP=OFF -DENABLE_GLIB=ON -DENABLE_QT4=OFF -DENABLE_QT5=OFF  -DBUILD_GTK_TESTS=OFF -DENABLE_SPLASH=OFF -DENABLE_UTILS=OFF

--- a/install_pdfparser.sh
+++ b/install_pdfparser.sh
@@ -14,17 +14,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pdfparser.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Original version by Ivan Zderadicka  (https://github.com/izderadicka/pdfparser)
-# Adopted and modified by Rossum (https://github.com/rossumai/pdfparser)
 
 set -e
 
 # install without sudo while inside virtualenv
 need_sudo=`python -c 'import sys; print(not hasattr(sys, "real_prefix") and (not hasattr(sys, "base_prefix") or sys.prefix == sys.base_prefix))'`
 
-sudo apt-get update
-sudo apt-get install -y cmake libtool pkg-config gettext libfontconfig1-dev autoconf libzip-dev libtiff5-dev libopenjpeg-dev
+sudo apt-get install -y pkg-config libfontconfig1 libzip4 libtiff5 libopenjpeg5
 
 if [[ ${need_sudo} == 'True' ]]; then sudo pip install -r requirements.txt; else pip install -r requirements.txt; fi
 
@@ -34,17 +30,12 @@ if [[ ${need_sudo} == 'True' ]]; then sudo pip install -r requirements.txt; else
 # python setup.py install
 
 sudo apt-get install -y libcairo2 libcairo2-dev
-git clone --depth 1 --branch poppler-0.61.1 https://anongit.freedesktop.org/git/poppler/poppler.git
 git clone --depth 1 --branch v1.15.4 https://github.com/pygobject/pycairo.git
 
-cd poppler
-cmake -DCMAKE_BUILD_TYPE=release -DENABLE_CPP=OFF -DENABLE_GLIB=ON -DENABLE_QT4=OFF -DENABLE_QT5=OFF  -DBUILD_GTK_TESTS=OFF -DENABLE_SPLASH=OFF -DENABLE_UTILS=OFF
-make
+cp poppler/libpoppler.so.?? pdfparser/
+cp poppler/glib/libpoppler-glib.so.? pdfparser/
 
-cp libpoppler.so.?? ../pdfparser/
-cp glib/libpoppler-glib.so.? ../pdfparser/
-
-cd ../pycairo
+cd pycairo
 if [[ ${need_sudo} == 'True' ]]; then sudo python setup.py install; else python setup.py install; fi
 cd ..
 


### PR DESCRIPTION
This is the second part of the attempt to be able to run `install_pdfparser.sh` inside a Docker container. The main changes are:

- remove `sudo` from the script because there is no `sudo` in the container
- install `git` because there is no `git` in the container

BTW, if the `chown` line is too problematic, we can move the `apt install` line into README. Then we wouldn't have to run the script with `sudo` and thus we wouldn't have to change the owner.