### PR TITLE
Dockerize PDFParser installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
 sudo ./install_fonts.sh
 sudo ./build_poppler.sh
+sudo apt-get install -y libcairo2 libcairo2-dev libfontconfig1 libopenjpeg5 libtiff5 libzip4 pkg-config
+# If not in virtualenv, run install_pdfparser.sh with sudo
 ./install_pdfparser.sh
 #test that it works
 python tests/dump_file.py test_docs/test1.pdf

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone --depth 1 https://github.com/rossumai/pdfparser.git
 cd pdfparser
 sudo ./install_fonts.sh
 sudo ./build_poppler.sh
-sudo apt-get install -y libcairo2 libcairo2-dev libfontconfig1 libopenjpeg5 libtiff5 libzip4 pkg-config
+sudo apt-get install -y coreutils g++ gcc git libcairo2 libcairo2-dev libfontconfig1 libopenjpeg5 libtiff5 libzip4 pkg-config python-dev
 # If not in virtualenv, run install_pdfparser.sh with sudo
 ./install_pdfparser.sh
 #test that it works

--- a/install_pdfparser.sh
+++ b/install_pdfparser.sh
@@ -17,42 +17,27 @@
 
 set -e
 
-# install without sudo while inside virtualenv
-need_sudo=`python -c 'import sys; print(not hasattr(sys, "real_prefix") and (not hasattr(sys, "base_prefix") or sys.prefix == sys.base_prefix))'`
-
-sudo apt-get install -y pkg-config libfontconfig1 libzip4 libtiff5 libopenjpeg5
-
-if [[ ${need_sudo} == 'True' ]]; then sudo pip install -r requirements.txt; else pip install -r requirements.txt; fi
+pip install -r requirements.txt
 
 # This would be ideal way to install pdfparser but some cairo-specific headers
 # are just not included in any of poppler related packages
 # sudo apt-get install -y libpoppler-dev libpoppler-private-dev libpoppler-glib-dev python-cairo-dev
 # python setup.py install
 
-sudo apt-get install -y libcairo2 libcairo2-dev
 git clone --depth 1 --branch v1.15.4 https://github.com/pygobject/pycairo.git
 
 cp poppler/libpoppler.so.?? pdfparser/
 cp poppler/glib/libpoppler-glib.so.? pdfparser/
 
 cd pycairo
-if [[ ${need_sudo} == 'True' ]]; then sudo python setup.py install; else python setup.py install; fi
+python setup.py install
 cd ..
 
-if [[ ${need_sudo} == 'True' ]]
-then
-    sudo POPPLER_CAIRO_ROOT='.' python setup.py install
-    # build a source and binary package
-    sudo POPPLER_CAIRO_ROOT='.' python setup.py sdist
-    sudo POPPLER_CAIRO_ROOT='.' python setup.py bdist_wheel
-    sudo rm -rf build dist pdfparser.egg-info
-else
-    POPPLER_CAIRO_ROOT='.' python setup.py install
-    # build a source and binary package
-    POPPLER_CAIRO_ROOT='.' python setup.py sdist
-    POPPLER_CAIRO_ROOT='.' python setup.py bdist_wheel
-    rm -rf build dist pdfparser.egg-info
-fi
+POPPLER_CAIRO_ROOT='.' python setup.py install
+# build a source and binary package
+POPPLER_CAIRO_ROOT='.' python setup.py sdist
+POPPLER_CAIRO_ROOT='.' python setup.py bdist_wheel
+rm -rf build dist pdfparser.egg-info
 
 # can be installed with: pip install dist/*.whl
 # publishing:
@@ -64,9 +49,4 @@ fi
 ### production PyPI;
 # twine upload twine upload dist/*
 
-if [[ ${need_sudo} == 'True' ]]
-then
-    sudo rm -rf poppler pycairo
-else
-    rm -rf poppler pycairo
-fi
+rm -rf poppler pycairo


### PR DESCRIPTION
This is the last part of the attempt to be able to run install_pdfparser.sh inside a Docker container. The main changes are:

- remove `sudo` from the script because there is no `sudo` in the container
- install `git` because there is no `git` in the container
